### PR TITLE
Improve description for dub search discovery

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -1,5 +1,5 @@
 name "expected"
-description "Implementation of expected idiom for D"
+description "Implementation of expected idiom (error handling with ok and err)"
 authors "Tomáš Chaloupka"
 copyright "Copyright © 2019, Tomáš Chaloupka"
 license "BSL-1.0"


### PR DESCRIPTION
Removes "for D" as per dub recommendation that all packages on dub are for D and explicitly stating this is discouraged unless it's a port of another language's library.

Adds ok and err to the description to be more discoverable in search.

Saw this once when it was released but then couldn't find it again until I googled "dlang ok err"

Will require a new version release as otherwise dub doesn't pick it up.