### PR TITLE
Allow @system pred

### DIFF
--- a/tests/expected.d
+++ b/tests/expected.d
@@ -453,3 +453,11 @@ unittest
     assert(empty.value == int.init);
     assert(empty.error is null);
 }
+
+@("system pred")
+@system unittest
+{
+    auto foo() @system { return ok; }
+    static assert(__traits(compiles, ok.andThen!foo));
+    static assert(__traits(compiles, err("foo").orElse!foo));
+}


### PR DESCRIPTION
Top-level `@safe` disables attribute inference and requieres from all template instantiations to be `@safe`. Hence, use of `@system` `pred` in `andThen` and `orElse` breaks compilation.

This patch removes top-level `@safe` and lets attribute inference to do its job. Also it marks appropriate non-templated functions as `@safe` on per function level. Calls to `pureGcRemoveRange` and `pureFree` are now expliciltly trusted, as it is the case with `pureMalloc`, `pureCalloc`, and `pureGcAddRange` in `@trusted` `allocateStore`.