### PR TITLE
Fix Unexpected ctor storing error value

### DIFF
--- a/source/expected.d
+++ b/source/expected.d
@@ -1306,10 +1306,10 @@ version (D_Exceptions)
         {
             import core.lifetime : forward;
             import std.traits : isAssignable;
-            static if (isAssignable!(string, T)) super(forward!value, file, line);
+            static if (isAssignable!(string, T)) super(value, file, line);
             else super("Unexpected error", file, line);
 
-            this.error = error;
+            this.error = forward!value;
         }
     }
 }


### PR DESCRIPTION
## Summary

The `Unexpected` exception constructor at `source/expected.d:1312` had `this.error = error;` — assigning the field to itself rather than the `value` parameter. As a result, the error value was never actually stored on the exception.

Newer compilers now emit:

```
source/expected.d(1312,13): Deprecation: cannot initialize field `error` with itself
             this.error = error;
             ^
```

This will eventually become a hard error.

## Fix

```diff
-            static if (isAssignable!(string, T)) super(forward!value, file, line);
+            static if (isAssignable!(string, T)) super(value, file, line);
             else super("Unexpected error", file, line);

-            this.error = error;
+            this.error = forward!value;
```

I also dropped the `forward!value` from the `super(...)` call. Otherwise we'd be forwarding `value` to `super` *and* to `this.error`, which would use `value` after a potential move. The `static if` branch only fires when `T` is assignable to `string` (slice types — no meaningful move semantics), so passing `value` by ref to `super` is safe.

## Test plan

- [x] `dub test` — 43/43 pass
- [x] `dub build` — clean, no deprecation